### PR TITLE
corrected event timings - Debug or Die

### DIFF
--- a/src/data/tvData.js
+++ b/src/data/tvData.js
@@ -92,11 +92,15 @@ export const eventTimeLine = [
         id: 6,
         title: "Debug (or) Die",
         date: "2025-08-01",
-        time: "10:00 AM - 12:30 PM",
+        time: "10:00 AM - 4:30 PM",
         formlink: "",
         description:
-          "Fix buggy code faster than your rivals in a high-stakes debugging battle. Think like a compiler, race against time, and prove your eye for errors in a game of logic and speed—where precision, focus, and quick thinking are everything.",
-        highlights: ["Real Bugs", "Speed Test", "Logic Puzzles"],
+          "Escape-room-style challenge where code detectives race against time to debug, decode, and escape! A thrilling test of logic, technical skills, and critical thinking.",
+        highlights: [
+          "Escape-Room Challenge",
+          "Code & Logic Puzzles",
+          "Team-Based Competition"
+        ],
         icon: "🔍",
         image: "/events/Technovista2025/DebugOrDie/Cartoon.jpg",
         cartoon: "/events/Technovista2025/DebugOrDie/Cartoon.jpg",


### PR DESCRIPTION
This pull request updates the event details for "Debug (or) Die" in the `eventTimeLine` array within the `src/data/tvData.js` file. The changes include adjustments to the event timing, description, and highlights to better reflect the updated format and theme of the event.

### Event updates:
* **Event timing**: Corrected the event duration from "10:00 AM - 12:30 PM" to "10:00 AM - 4:30 PM".
* **Description**: Updated the description to reflect the new escape-room-style challenge, emphasizing debugging, decoding, and critical thinking.
* **Highlights**: Replaced the original highlights with new ones that align with the updated event format, including "Escape-Room Challenge," "Code & Logic Puzzles," and "Team-Based Competition."